### PR TITLE
Fixed typo on class reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ All Action Controller modules know about their dependent modules, so you can fee
 Some common modules you might want to add:
 
 * *AbstractController::Translation*: Support for the *l* and *t* localization and translation methods. These delegate to *I18n.translate* and *I18n.localize*.
-* *ActionController::HTTPAuthentication::Basic* (or *Digest* or *Token*): Support for basic, digest or token HTTP authentication.
+* *ActionController::HttpAuthentication::Basic* (or *Digest* or *Token*): Support for basic, digest or token HTTP authentication.
 * *AbstractController::Layouts*: Support for layouts when rendering.
 * *ActionController::MimeResponds*: Support for content negotiation (*respond_to*, *respond_with*).
 * *ActionController::Cookies*: Support for *cookies*, which includes support for signed and encrypted cookies. This requires the cookie middleware.


### PR DESCRIPTION
- The class is ActionController::HttpAuthentication::Basic rather than
  HTTPAuthentication.

This ought to save debugging time for other devs :)
