### PR TITLE
Added compatibility to 'helper_method'

### DIFF
--- a/lib/rails-api/action_controller/api.rb
+++ b/lib/rails-api/action_controller/api.rb
@@ -98,6 +98,7 @@ module ActionController
       def wrap_parameters(*); end
       def helpers_path=(*); end
       def allow_forgery_protection=(*); end
+      def helper_method(*); end
     end
 
     extend Compabitility


### PR DESCRIPTION
There are many gems that depend on the "helper_method" (like devise). This commit just add an stub for this method in ActionController::API::Compabitility module.
