### PR TITLE
Fix test_helper for Ruby 1.8.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,23 +6,27 @@ require 'rails/test_help'
 require 'rails-api'
 
 def app
-  @@app ||= Class.new(Rails::Application) do
-    config.active_support.deprecation = :stderr
-    config.generators do |c|
-      c.orm :active_record, :migration => true,
-                            :timestamps => true
+  unless defined?(@@app)
+    @@app = Class.new(Rails::Application)
+    @@app.class_eval do
+      config.active_support.deprecation = :stderr
+      config.generators do |c|
+        c.orm :active_record, :migration => true,
+                              :timestamps => true
 
-      c.test_framework :test_unit, :fixture => true,
-                                   :fixture_replacement => nil
+        c.test_framework :test_unit, :fixture => true,
+                                     :fixture_replacement => nil
 
-      c.integration_tool :test_unit
-      c.performance_tool :test_unit
-    end
+        c.integration_tool :test_unit
+        c.performance_tool :test_unit
+      end
 
-    def self.name
-      'TestApp'
+      def self.name
+        'TestApp'
+      end
     end
   end
+  @@app
 end
 
 app.routes.append do


### PR DESCRIPTION
`Class.new` does not accept a block for evaluation in Ruby 1.8, so I replaced the block with a call to `class_eval`. This is wrapped in an `unless defined?` to keep the memoization functionality.

Before this change, running the test suite returned `./test/test_helper.rb:10:in `app': undefined local variable or method `config' for #<Class:0x7fb9872bc210> (NameError)`, which you can see in [Travis build 3.1 for Rails::API](https://travis-ci.org/rails-api/rails-api/jobs/3319620).
