### PR TITLE
Remove BestStandardsSupport from rails 4 stack since it was removed

### DIFF
--- a/lib/rails-api/application.rb
+++ b/lib/rails-api/application.rb
@@ -98,10 +98,6 @@ module Rails
         middleware.use ::Rack::Head
         middleware.use ::Rack::ConditionalGet
         middleware.use ::Rack::ETag, "no-cache"
-
-        if config.action_dispatch.best_standards_support
-          middleware.use ::ActionDispatch::BestStandardsSupport, config.action_dispatch.best_standards_support
-        end
       end
     end
 

--- a/test/api_application/api_application_test.rb
+++ b/test/api_application/api_application_test.rb
@@ -69,7 +69,6 @@ class ApiApplicationTest < ActiveSupport::TestCase
       "Rack::Head",
       "Rack::ConditionalGet",
       "Rack::ETag",
-      "ActionDispatch::BestStandardsSupport"
     ]
   end
 end


### PR DESCRIPTION
See here:
https://github.com/rails/rails/commit/3bccd12373567bf9369f44522599b7d61a006f60

cc @guilleiguaran
