### PR TITLE
Removed new action from templates and tests

### DIFF
--- a/lib/rails-api/templates/rails/scaffold_controller/controller.rb
+++ b/lib/rails-api/templates/rails/scaffold_controller/controller.rb
@@ -16,14 +16,6 @@ class <%= controller_class_name %>Controller < ApplicationController
     render json: <%= "@#{singular_table_name}" %>
   end
 
-  # GET <%= route_url %>/new
-  # GET <%= route_url %>/new.json
-  def new
-    @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
-
-    render json: <%= "@#{singular_table_name}" %>
-  end
-
   # POST <%= route_url %>
   # POST <%= route_url %>.json
   def create

--- a/lib/rails-api/templates/test_unit/scaffold/functional_test.rb
+++ b/lib/rails-api/templates/test_unit/scaffold/functional_test.rb
@@ -12,11 +12,6 @@ class <%= controller_class_name %>ControllerTest < ActionController::TestCase
     assert_not_nil assigns(:<%= table_name %>)
   end
 
-  test "should get new" do
-    get :new
-    assert_response :success
-  end
-
   test "should create <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count') do
       post :create, <%= "#{singular_table_name}: { #{attributes_hash} }" %>

--- a/test/generators/scaffold_generator_test.rb
+++ b/test/generators/scaffold_generator_test.rb
@@ -46,10 +46,6 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
         assert_match(/@product_line = ProductLine\.find\(params\[:id\]\)/, m)
       end
 
-      assert_instance_method :new, content do |m|
-        assert_match(/@product_line = ProductLine\.new/, m)
-      end
-
       assert_instance_method :create, content do |m|
         assert_match(/@product_line = ProductLine\.new\(params\[:product_line\]\)/, m)
         assert_match(/@product_line\.save/, m)


### PR DESCRIPTION
Since the new action is not generated in the routes file, tests in a new application with a scaffold generated controller fail. There is a test looking for the new action and no route matches. Removed that test.

Also, if there is no new route when scaffolding, there's no need to generate it in the controller. Removed the new method from the scaffold controller template.

Finally, remove the rails-api (now) failing test checking that a generated controller should have the new action.
