### PR TITLE
Test javascipts aren't generated via scaffold

### DIFF
--- a/test/generators/scaffold_generator_test.rb
+++ b/test/generators/scaffold_generator_test.rb
@@ -93,5 +93,6 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     # Assets
     assert_no_file "app/assets/stylesheets/scaffold.css"
     assert_no_file "app/assets/stylesheets/product_lines.css"
+    assert_no_file "app/assets/javascripts/product_lines.js"
   end
 end


### PR DESCRIPTION
I have verified that this test fails without the change in #76, and passes with it.
