### PR TITLE
check major rails version directly

### DIFF
--- a/lib/rails-api.rb
+++ b/lib/rails-api.rb
@@ -5,7 +5,7 @@ require 'rails-api/application'
 module Rails
   module API
     def self.rails4?
-      Rails.version.start_with? '4'
+      Rails::VERSION::MAJOR == 4
     end
   end
 end


### PR DESCRIPTION
In Rails 4, Rails.version returns an instance of Gem::Version.
Instead, we can check the major rails version directly.
