### PR TITLE
rails 4 fix ActionDispatch::BestStandardsSupport

### DIFF
--- a/lib/rails-api/application.rb
+++ b/lib/rails-api/application.rb
@@ -143,7 +143,9 @@ module Rails
         middleware.use ::Rack::ETag, "no-cache"
 
         if !config.api_only && config.action_dispatch.best_standards_support
-          middleware.use ::ActionDispatch::BestStandardsSupport, config.action_dispatch.best_standards_support
+          if defined?(::ActionDispatch::BestStandardsSupport)
+            middleware.use ::ActionDispatch::BestStandardsSupport, config.action_dispatch.best_standards_support
+          end
         end
       end
     end


### PR DESCRIPTION
kmandrup:rails-api (master) $ rake test
Run options:
# Running tests:

Finished tests in 4.186601s, 4.7771 tests/s, 32.0069 assertions/s.
20 tests, 134 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-darwin12.2.0]
