### PR TITLE
Fix mistaken reference to --skip-test-unit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Rails includes all of the sub-frameworks (ActiveRecord, ActionMailer, etc) by de
 
 This can also be achieved with flags when creating a new **Rails::API** app:
 
-    rails-api new my_api --skip-test-unit --skip-sprockets
+    rails-api new my_api --skip-action-mailer --skip-sprockets
 
 Note: There are references to ActionMailer and ActiveRecord in the various
   config/environment files. If you decide to exclude any of these from your project


### PR DESCRIPTION
This comment in the README mentioned using the options --skip-test-unit
and --skip-sprockets, but `rails/test_unit/railtie` isn't the one that's commented
out. `action_mailer/railtie` is.

Signed-off-by: David Celis me@davidcel.is
