### PR TITLE
Rails 4 Strong Parameters Fix

### DIFF
--- a/lib/rails-api/action_controller/api.rb
+++ b/lib/rails-api/action_controller/api.rb
@@ -150,7 +150,7 @@ module ActionController
       include mod
     end
     
-    if Rails::API.rails4?
+    if Rails::VERSION::MAJOR == 4
       include StrongParameters
     end
 


### PR DESCRIPTION
This fork fixes the Rails 4 bug wherein using strong parameters produces the TypeError `can’t convert Symbol into String` by including ActionController::StrongParameters in ActionController::API if the current version of Rails is Rails 4.
