### PR TITLE
Remove deprecated finders gem

### DIFF
--- a/Gemfile.edge
+++ b/Gemfile.edge
@@ -3,6 +3,3 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'rails', github: 'rails/rails', branch: 'master'
-
-# Current dependencies of edge rails
-gem 'activerecord-deprecated_finders' , github: 'rails/activerecord-deprecated_finders', branch: 'master'


### PR DESCRIPTION
They're no longer edge rails dependecy

https://github.com/rails/rails/commit/3cc7223f3d57f31affdbabccc86cbc8b6589e2c8
