### PR TITLE
Refactor the Rails 4 path for Application#default_middleware_stack.

### DIFF
--- a/lib/rails-api/application.rb
+++ b/lib/rails-api/application.rb
@@ -1,12 +1,13 @@
 require 'rails/version'
 require 'rails/application'
 require 'rails-api/public_exceptions'
+require 'rails-api/application/default_rails_four_middleware_stack'
 
 module Rails
   class Application < Engine
     def default_middleware_stack
       if Rails::API.rails4?
-        rails_four_stack
+        DefaultRailsFourMiddlewareStack.new(self, config, paths).build_stack
       else
         rails_three_stack
       end
@@ -34,72 +35,6 @@ module Rails
     ActiveSupport.on_load(:before_configuration) do
       config.api_only = true
       setup_generators!
-    end
-
-    def rails_four_stack
-      ActionDispatch::MiddlewareStack.new.tap do |middleware|
-        app = self
-        if rack_cache = config.action_dispatch.rack_cache
-          begin
-            require 'rack/cache'
-          rescue LoadError => error
-            error.message << ' Be sure to add rack-cache to your Gemfile'
-            raise
-          end
-
-          if rack_cache == true
-            rack_cache = {
-              metastore: "rails:/",
-              entitystore: "rails:/",
-              verbose: false
-            }
-          end
-
-          require "action_dispatch/http/rack_cache"
-          middleware.use ::Rack::Cache, rack_cache
-        end
-
-        if config.force_ssl
-          middleware.use ::ActionDispatch::SSL, config.ssl_options
-        end
-
-        if config.action_dispatch.x_sendfile_header.present?
-          middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
-        end
-
-        if config.serve_static_assets
-          middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control
-        end
-
-        middleware.use ::Rack::Lock unless config.cache_classes
-        middleware.use ::Rack::Runtime
-        middleware.use ::Rack::MethodOverride unless config.api_only
-        middleware.use ::ActionDispatch::RequestId
-        middleware.use ::Rails::Rack::Logger, config.log_tags # must come after Rack::MethodOverride to properly log overridden methods
-        middleware.use ::ActionDispatch::ShowExceptions, config.exceptions_app || ActionDispatch::PublicExceptions.new(Rails.public_path)
-        middleware.use ::ActionDispatch::DebugExceptions, app
-        middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
-
-        unless config.cache_classes
-          middleware.use ::ActionDispatch::Reloader, lambda { app.reload_dependencies? }
-        end
-
-        middleware.use ::ActionDispatch::Callbacks
-        middleware.use ::ActionDispatch::Cookies unless config.api_only
-
-        if !config.api_only && config.session_store
-          if config.force_ssl && !config.session_options.key?(:secure)
-            config.session_options[:secure] = true
-          end
-          middleware.use config.session_store, config.session_options
-          middleware.use ::ActionDispatch::Flash
-        end
-
-        middleware.use ::ActionDispatch::ParamsParser
-        middleware.use ::Rack::Head
-        middleware.use ::Rack::ConditionalGet
-        middleware.use ::Rack::ETag, "no-cache"
-      end
     end
 
     def rails_three_stack

--- a/lib/rails-api/application/default_rails_four_middleware_stack.rb
+++ b/lib/rails-api/application/default_rails_four_middleware_stack.rb
@@ -1,0 +1,101 @@
+module Rails
+  class Application
+    class DefaultRailsFourMiddlewareStack
+      attr_reader :config, :paths, :app
+
+      def initialize(app, config, paths)
+        @app = app
+        @config = config
+        @paths = paths
+      end
+
+      def build_stack
+        ActionDispatch::MiddlewareStack.new.tap do |middleware|
+          if rack_cache = load_rack_cache
+            require "action_dispatch/http/rack_cache"
+            middleware.use ::Rack::Cache, rack_cache
+          end
+
+          if config.force_ssl
+            middleware.use ::ActionDispatch::SSL, config.ssl_options
+          end
+
+          if config.action_dispatch.x_sendfile_header.present?
+            middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
+          end
+
+          if config.serve_static_assets
+            middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control
+          end
+
+          middleware.use ::Rack::Lock unless allow_concurrency?
+          middleware.use ::Rack::Runtime
+          middleware.use ::Rack::MethodOverride unless config.api_only
+          middleware.use ::ActionDispatch::RequestId
+
+          # Must come after Rack::MethodOverride to properly log overridden methods
+          middleware.use ::Rails::Rack::Logger, config.log_tags
+          middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
+          middleware.use ::ActionDispatch::DebugExceptions, app
+          middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
+
+          unless config.cache_classes
+            middleware.use ::ActionDispatch::Reloader, lambda { reload_dependencies? }
+          end
+
+          middleware.use ::ActionDispatch::Callbacks
+          middleware.use ::ActionDispatch::Cookies unless config.api_only
+
+          if !config.api_only && config.session_store
+            if config.force_ssl && !config.session_options.key?(:secure)
+              config.session_options[:secure] = true
+            end
+            middleware.use config.session_store, config.session_options
+            middleware.use ::ActionDispatch::Flash
+          end
+
+          middleware.use ::ActionDispatch::ParamsParser
+          middleware.use ::Rack::Head
+          middleware.use ::Rack::ConditionalGet
+          middleware.use ::Rack::ETag, "no-cache"
+        end
+      end
+
+      private
+
+        def reload_dependencies?
+          config.reload_classes_only_on_change != true || app.reloaders.map(&:updated?).any?
+        end
+
+        def allow_concurrency?
+          config.allow_concurrency.nil? ? config.cache_classes : config.allow_concurrency
+        end
+
+        def load_rack_cache
+          rack_cache = config.action_dispatch.rack_cache
+          return unless rack_cache
+
+          begin
+            require 'rack/cache'
+          rescue LoadError => error
+            error.message << ' Be sure to add rack-cache to your Gemfile'
+            raise
+          end
+
+          if rack_cache == true
+            {
+              metastore: "rails:/",
+              entitystore: "rails:/",
+              verbose: false
+            }
+          else
+            rack_cache
+          end
+        end
+
+        def show_exceptions_app
+          config.exceptions_app || ActionDispatch::PublicExceptions.new(Rails.public_path)
+        end
+    end
+  end
+end


### PR DESCRIPTION
This is backwards compatible with 4.0.x and reflects the changes done in the Rails 4.1 refactor here:
https://github.com/rails/rails/commit/685309cf590cb49512bfd28b342d8aaa6c9f42eb

This also fixes the remaining failing test for ApiApplicationTest#test_boot_api_app.  Unfortunately, the app throwing a 500 makes that test fail, so both PR #111 and this PR are required to make that test pass.  This fixes issue #112.
