### PR TITLE
Change Travis configuration to 'rbx' instead of 'rbx-19mode'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc', '~> 1.4.10'
+end

--- a/Gemfile.edge
+++ b/Gemfile.edge
@@ -1,6 +1,11 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec
 
 gem 'rails', github: 'rails/rails', branch: 'master'
 gem 'arel', github: 'rails/arel', branch: 'master'
+
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc', '~> 1.4.10'
+end


### PR DESCRIPTION
This fixes the broken build status for Rubinius builds.  See https://github.com/travis-ci/travis-ci/issues/1641 if you'd like more context.
