### PR TITLE
Update bcrypt-ruby Version in Gemfile Template

### DIFF
--- a/lib/rails-api/templates/rails/app/Gemfile
+++ b/lib/rails-api/templates/rails/app/Gemfile
@@ -10,7 +10,7 @@ gem 'rails-api'
 <%= "gem 'json'\n" if RUBY_VERSION < "1.9.2" -%>
 
 # To use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.0.0'
+# gem 'bcrypt-ruby', '~> 3.1.2'
 
 # To use Jbuilder templates for JSON
 # gem 'jbuilder'


### PR DESCRIPTION
When using the current version of rails-api for a project, I came across a strange error with bcrypt-ruby.  By default, the Gemfile template included version **3.0.0**.  The rails/rails master branch has updated to bcrypt-ruby version 3.1.2, so I did the same for rails-api.  This error is now gone when someone uses the version specified in the template Gemfile:

> You don't have bcrypt-ruby installed in your application. Please add it to your Gemfile and run bundle install
> Completed 500 Internal Server Error in 2ms
