### PR TITLE
Move require for 'rails/version' to the file that needs it

### DIFF
--- a/lib/rails-api.rb
+++ b/lib/rails-api.rb
@@ -1,3 +1,4 @@
+require 'rails/version'
 require 'rails-api/version'
 require 'rails-api/action_controller/api'
 require 'rails-api/application'

--- a/lib/rails-api/application.rb
+++ b/lib/rails-api/application.rb
@@ -1,4 +1,3 @@
-require 'rails/version'
 require 'rails/application'
 require 'rails-api/public_exceptions'
 require 'rails-api/application/default_rails_four_middleware_stack'


### PR DESCRIPTION
The file that causes rails/version to be loaded is not the same file that uses it. This is not a problem _per se_, but when running a generator, the `Rails::Application` might not get loaded, causing the calls to `Rails::Api.rails4?` to fail with:

```
rails-api-0.2.0/lib/rails-api/action_controller/api.rb:149:in '<class:API>': uninitialized constant Rails::VERSION (NameError)
```
