### PR TITLE
Adds self.protected_instance_variables to ActionController::API

### DIFF
--- a/lib/rails-api/action_controller/api.rb
+++ b/lib/rails-api/action_controller/api.rb
@@ -155,6 +155,10 @@ module ActionController
       include mod
     end
 
+    def self.protected_instance_variables
+      Set.new
+    end
+
     if Rails::VERSION::MAJOR >= 4
       include StrongParameters
     end


### PR DESCRIPTION
This enables compatibility with the decent_exposure gem (and others). It implements the `self.protected_instance_variables` method in `ActionController::Base` (as of Rails 4.1). 

This is the cause of the issue referenced [here](https://github.com/rails-api/rails-api/issues/135)
