### PR TITLE
Adding info on removing protect_from_forgery to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ class ApplicationController < ActionController::API
 end
 ```
 
-And comment out the `protect_from_forgery` call if you are using it.
+And comment out the `protect_from_forgery` call if you are using it. (You aren't using cookie-based authentication for your API, are you?)
 
 If you want to use the Rails default middleware stack (avoid the reduction that rails-api does), you can just add config.api_only = false to config/application.rb file.
 


### PR DESCRIPTION
The implications of removing `protect_from_forgery` aren't made clear, which might be a big deal for the average user who likely relies on Rails to know best when it comes to things like authentication. 

I can imagine there being a bunch of sites using rails-api with cookie-based auth and CSRF turned off. If using cookie-based auth is a requirement, there are workarounds for to inject CSRF headers into AJAX requests. 

It's not really a simple issue, so I tried adding a question to the readme that would make the potential user investigate. It's also possible that it might make more sense to just link to information about token-based authentication in Rails, which I'd assume is what's typically used with APIs.
