### PR TITLE
Whitelisted params generation in controller actions

### DIFF
--- a/lib/rails-api/templates/rails/scaffold_controller/controller.rb
+++ b/lib/rails-api/templates/rails/scaffold_controller/controller.rb
@@ -19,7 +19,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # POST <%= route_url %>
   # POST <%= route_url %>.json
   def create
-    @<%= singular_table_name %> = <%= orm_class.build(class_name, "params[:#{singular_table_name}]") %>
+    @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
 
     if @<%= orm_instance.save %>
       render json: <%= "@#{singular_table_name}" %>, status: :created, location: <%= "@#{singular_table_name}" %>
@@ -33,7 +33,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   def update
     @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
 
-    if @<%= Rails::API.rails4? ? orm_instance.update("params[:#{singular_table_name}]") : orm_instance.update_attributes("params[:#{singular_table_name}]") %>
+    if @<%= Rails::API.rails4? ? orm_instance.update("#{singular_table_name}_params") : orm_instance.update_attributes("params[:#{singular_table_name}]") %>
       head :no_content
     else
       render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity

--- a/test/generators/scaffold_generator_test.rb
+++ b/test/generators/scaffold_generator_test.rb
@@ -47,7 +47,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :create, content do |m|
-        assert_match(/@product_line = ProductLine\.new\(params\[:product_line\]\)/, m)
+        assert_match(/@product_line = ProductLine\.new\(product_line_params\)/, m)
         assert_match(/@product_line\.save/, m)
         assert_match(/@product_line\.errors/, m)
       end
@@ -55,9 +55,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :update, content do |m|
         assert_match(/@product_line = ProductLine\.find\(params\[:id\]\)/, m)
         if rails4?
-          assert_match(/@product_line\.update\(params\[:product_line\]\)/, m)
+          assert_match(/@product_line\.update\(product_line_params\)/, m)
         else
-          assert_match(/@product_line\.update_attributes\(params\[:product_line\]\)/, m)
+          assert_match(/@product_line\.update_attributes\(product_line_params\)/, m)
         end
         assert_match(/@product_line\.errors/, m)
       end


### PR DESCRIPTION
Improvement over previous pull request. Now generates params in controller actions.

From

```
def create
  @foo = Foo.new(params[:foo])
  ...
end
```

to

```
def create
  @foo = Foo.new(foo_params)
  ...
end
```
