### PR TITLE
Fix app template: fetch `secret_key_base` from the new `secrets.yml` file

### DIFF
--- a/lib/rails-api/templates/rails/app/config/application.rb
+++ b/lib/rails-api/templates/rails/app/config/application.rb
@@ -1,0 +1,34 @@
+require File.expand_path('../boot', __FILE__)
+
+<% if include_all_railties? -%>
+require 'rails/all'
+<% else -%>
+# Pick the frameworks you want:
+require "active_model/railtie"
+<%= comment_if :skip_active_record %>require "active_record/railtie"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+<%= comment_if :skip_action_view %>require "action_view/railtie"
+<%= comment_if :skip_sprockets %>require "sprockets/railtie"
+<%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
+<% end -%>
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
+
+module <%= app_const_base %>
+  class Application < Rails::Application
+    # Settings in config/environments/* take precedence over those specified here.
+    # Application configuration should go into files in config/initializers
+    # -- all .rb files in that directory are automatically loaded.
+
+    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
+    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
+    # config.time_zone = 'Central Time (US & Canada)'
+
+    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
+    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+    # config.i18n.default_locale = :de
+  end
+end

--- a/lib/rails-api/templates/rails/app/config/application.rb
+++ b/lib/rails-api/templates/rails/app/config/application.rb
@@ -13,6 +13,8 @@ require "action_mailer/railtie"
 <%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
 <% end -%>
 
+require "yaml"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/lib/rails-api/templates/rails/app/config/initializers/secret_token.rb.tt
+++ b/lib/rails-api/templates/rails/app/config/initializers/secret_token.rb.tt
@@ -16,4 +16,4 @@
 # Using secret_token for rails3 compatibility. Change to secret_key_base
 # to avoid deprecation warning.
 # Can be safely removed in a rails3 api-only application.
-<%= app_const %>.config.secret_token = '<%= app_secret %>'
+<%= app_const %>.config.secret_token = Rails.application.secrets.secret_key_base


### PR DESCRIPTION
**As a** developer 
**In order to** take benefit from the community best practices 
**I want** the Rails::API app generator to fetch the app `secret_key_base` from the new `config/secrets.yml` file