### PR TITLE
Add default parameter filtering

### DIFF
--- a/lib/rails-api/templates/rails/app/config/initializers/filter_parameter_logging.rb.tt
+++ b/lib/rails-api/templates/rails/app/config/initializers/filter_parameter_logging.rb.tt
@@ -1,0 +1,4 @@
+# Be sure to restart your server when you modify this file.
+
+# Configure sensitive parameters which will be filtered from the log file.
+Rails.application.config.filter_parameters += [:password]


### PR DESCRIPTION
This is the same initalizer as the normal rails generator creates.

It means that by default passwords are filtered from logs and reminds users to
add the other parameters that need to be filtered.

Fixes issue #140 
