### PR TITLE
protected_instance_variables is compatible with Rails < 4.1

### DIFF
--- a/lib/rails-api/action_controller/api.rb
+++ b/lib/rails-api/action_controller/api.rb
@@ -155,8 +155,12 @@ module ActionController
       include mod
     end
 
+    DEFAULT_PROTECTED_INSTANCE_VARIABLES = begin
+      (Rails::VERSION::MAJOR < 4 || Rails::VERSION::MINOR < 1) ?  Array : Set
+    end.new
+
     def self.protected_instance_variables
-      Set.new
+      DEFAULT_PROTECTED_INSTANCE_VARIABLES
     end
 
     if Rails::VERSION::MAJOR >= 4


### PR DESCRIPTION
after upgrading to `0.3.0` I was getting a `TypeError: no implicit conversion of Set into Array`.

I found [this commit](https://github.com/rails/rails/commit/c8b566d54da278a8e675115bcf2e9590f75f5eb5) that makes this change, and that is where I'm getting my < 4.1 logic.

:two_hearts:
