### PR TITLE
include ImplictRender. This dependency is necessary to work with JBuilde...

### DIFF
--- a/lib/rails-api/action_controller/api.rb
+++ b/lib/rails-api/action_controller/api.rb
@@ -149,6 +149,7 @@ module ActionController
     if Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR > 0
       include AbstractController::Rendering
       include ActionView::Rendering
+      include ActionController::ImplicitRender
     end
 
     MODULES.each do |mod|


### PR DESCRIPTION
...r view templates.

Jbuilder is very usefull when we want to offer JSON return type from our app. Today using rails-api to create a simple REST/JSON Api was necessary to include this dependecy, ActionController::ImplicitRender, inside my controller .

Follow the sample code:
```ruby
module Api
	module V1
		class CostumersController < ActionController::API
		include ActionController::ImplicitRender

		before_filter :fetch_costumer, :except => [:index]

		def fetch_costumer
		  @costumer = Costumer.find_by_id(params[:id])
		end

		def index
			@costumers = Costumer.all
		end	

		def show
		 @costumer
		end 	

		# Never trust parameters from the scary internet, only allow the white list through.
		def costumer_params
		  params.require(:costumer).permit(:id)
		end

		end
	end
```
end		