### PR TITLE
Remove ActionController::HideActions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
   - ruby-head
   - jruby
   - rbx-2
@@ -15,10 +16,11 @@ gemfile:
 
 matrix:
   include:
-    - rvm: 2.1
+    - rvm: 2.2
       gemfile: Gemfile.edge
     - rvm: ruby-head
       gemfile: Gemfile.edge
+  allow_failures:
     - rvm: rbx-2
       gemfile: Gemfile.edge
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## master
 
+* Rubinius rubysl ~> 2.1 and added gem `psysch` into :rbx section of Gemfiles (@bearded)
+* Require Ruby 2.2 for Rails 5.0 (@bearded)
+* Removed ActionController::HideActions (@bearded)
+* bcrypt-ruby was renamed to bcrypt (@djbender)
+* Fixing use of deprecated `serve_static_assets` config option (@theunraveler)
 * ActionDispatch::Head replaced by Rack::Head (@bearded)
 * Converted Rails4 checks into Rails3 checks (@bearded)
 * Green tests on Rails 5.0.0.alpha (@bearded)

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 platforms :rbx do
-  gem 'rubysl', '~> 2.0'
-  gem 'racc', '~> 1.4.10'
+  gem 'rubysl', '~> 2.1'
+  gem 'racc'
+  gem 'psych'
 end

--- a/Gemfile.edge
+++ b/Gemfile.edge
@@ -6,6 +6,7 @@ gem 'rails', github: 'rails/rails', branch: 'master'
 gem 'arel', github: 'rails/arel', branch: 'master'
 
 platforms :rbx do
-  gem 'rubysl', '~> 2.0'
-  gem 'racc', '~> 1.4.10'
+  gem 'rubysl', '~> 2.1'
+  gem 'racc'
+  gem 'psych'
 end

--- a/lib/rails-api/action_controller/api.rb
+++ b/lib/rails-api/action_controller/api.rb
@@ -123,7 +123,6 @@ module ActionController
     end
 
     MODULES = [
-      HideActions,
       UrlFor,
       Redirecting,
       Rendering,
@@ -149,6 +148,10 @@ module ActionController
     if Rails::VERSION::MAJOR == 5 || (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR > 0)
       include AbstractController::Rendering
       include ActionView::Rendering
+    end
+
+    if Rails::VERSION::MAJOR < 5
+      include ActionController::HideActions
     end
 
     MODULES.each do |mod|

--- a/test/api_controller/action_methods_test.rb
+++ b/test/api_controller/action_methods_test.rb
@@ -3,15 +3,24 @@ require 'test_helper'
 class ActionMethodsApiController < ActionController::API
   def one; end
   def two; end
-  hide_action :two
+  # Rails 5 does not have method hide_action
+  if Rails::VERSION::MAJOR < 5
+    hide_action :two
+  end
 end
 
 class ActionMethodsApiTest < ActionController::TestCase
   tests ActionMethodsApiController
 
   def test_action_methods
-    assert_equal Set.new(%w(one)),
-                 @controller.class.action_methods,
-                 "#{@controller.controller_path} should not be empty!"
+    if Rails::VERSION::MAJOR < 5
+      assert_equal Set.new(%w(one)),
+                  @controller.class.action_methods,
+                  "#{@controller.controller_path} should not be empty!"
+    else
+      assert_equal Set.new(%w(one two)),
+                  @controller.class.action_methods,
+                  "#{@controller.controller_path} should not be empty!"
+    end
   end
 end


### PR DESCRIPTION
Remove ActionController::HideActions because of [Rails #18336](https://github.com/rails/rails/issues/18336)
Require Ruby 2.2 for Rails 5.0 because of [commit](https://github.com/rails/rails/commit/d3b098b8289ffaa8486f526dc53204123ed581f3)
Rubinius rubysl ~> 2.1 and added gem psysch into :rbx section of Gemfiles because of [commit](https://github.com/rubysl/rubysl/commit/697e4e2a53424f17dbbff925155c7c386c1139f4)
Added missing records into Changelog