### PR TITLE
Fixes Deprecation warning raised on 4.2

### DIFF
--- a/lib/rails-api/application.rb
+++ b/lib/rails-api/application.rb
@@ -37,6 +37,14 @@ module Rails
       config.api_only = true
       setup_generators!
     end
+    
+    def check_serve_static_files
+      if Rails::VERSION::MAJOR >= 5 || (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR > 1)
+        config.serve_static_files
+      else
+        config.serve_static_assets
+      end
+    end
 
     def rails3_stack
       ActionDispatch::MiddlewareStack.new.tap do |middleware|
@@ -53,11 +61,12 @@ module Rails
         if config.action_dispatch.x_sendfile_header.present?
           middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
         end
+        
 
-        if config.serve_static_assets
+        if check_serve_static_files
           middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control
         end
-
+        
         middleware.use ::Rack::Lock unless config.allow_concurrency
         middleware.use ::Rack::Runtime
         middleware.use ::Rack::MethodOverride unless config.api_only


### PR DESCRIPTION
Fixes this warning:

DEPRECATION WARNING: The configuration option `config.serve_static_assets` has been renamed to `config.serve_static_files` to clarify its role (it merely enables serving everything in the `public` folder and is unrelated to the asset pipeline). The `serve_static_assets` alias will be removed in Rails 5.0. Please migrate your configuration files accordingly.