### PR TITLE
Resolving the deprecation warning - active_support.test_order

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,9 @@ class ActiveSupport::TestCase
   def self.app
     @@app ||= Class.new(Rails::Application) do
       config.active_support.deprecation = :stderr
+
+      config.active_support.test_order = :random
+
       config.generators do |c|
         c.orm :active_record, :migration => true,
           :timestamps => true


### PR DESCRIPTION
This was the warning before my change:

```bash
DEPRECATION WARNING: You did not specify a value for the configuration option `active_support.test_order`. In Rails 5, the default value of this option will change from `:sorted` to `:random`.
To disable this warning and keep the current behavior, you can add the following line to your `config/environments/test.rb`:

  Rails.application.configure do
    config.active_support.test_order = :sorted
  end

Alternatively, you can opt into the future behavior by setting this option to `:random`. (called from test_order at /Users/adomokos/Programming/Ruby/oss/rails-api/vendor/bundle/ruby/2.0.0/gems/activesupport-4.2.1/lib/active_support/test_case.rb:42)
```

This is now resolved.