### PR TITLE
DRY-ing up a collection by swapping the element that's different

### DIFF
--- a/test/api_application/api_application_test.rb
+++ b/test/api_application/api_application_test.rb
@@ -37,23 +37,9 @@ class ApiApplicationTest < ActiveSupport::TestCase
   private
 
   def expected_middleware_stack_rails3
-    [
-      "ActionDispatch::Static",
-      "Rack::Lock",
-      "ActiveSupport::Cache::Strategy::LocalCache",
-      "Rack::Runtime",
-      "ActionDispatch::RequestId",
-      "Rails::Rack::Logger",
-      "ActionDispatch::ShowExceptions",
-      "ActionDispatch::DebugExceptions",
-      "ActionDispatch::RemoteIp",
-      "ActionDispatch::Reloader",
-      "ActionDispatch::Callbacks",
-      "ActionDispatch::ParamsParser",
-      "ActionDispatch::Head",
-      "Rack::ConditionalGet",
-      "Rack::ETag"
-    ]
+    expected_middleware_stack_rails.map do |x|
+      x == "ActionDispatch::Head" ? "Rack::Head" : x
+    end.flatten!
   end
 
   def expected_middleware_stack_rails


### PR DESCRIPTION
This refactoring makes it more obvious to what the difference is between the two collections these methods are providing.