### PR TITLE
Set secret key base to raise error if used

### DIFF
--- a/lib/rails-api/templates/rails/app/config/initializers/secret_token.rb.tt
+++ b/lib/rails-api/templates/rails/app/config/initializers/secret_token.rb.tt
@@ -1,19 +1,14 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-# You can use `rake secret` to generate a secure secret key.
-
-# Make sure your secret_key_base is kept private
-# if you're sharing your code publicly.
-
 # Although this is not needed for an api-only application, rails4 
 # requires secret_key_base or secret_token to be defined, otherwise an 
 # error is raised.
-# Using secret_token for rails3 compatibility. Change to secret_key_base
-# to avoid deprecation warning.
-# Can be safely removed in a rails3 api-only application.
-<%= app_const %>.config.secret_token = '<%= app_secret %>'
+#
+# Instead of setting it to a spurious string and risking broken security in
+# case it's ever really used, make an object that will raise an error in
+# that case.
+<%= app_const %>.config.secret_token = 
+<%= app_const %>.config.secret_key_base = 
+  Object.new.tap do |o|
+    def o.to_str
+      fail "secret key base not set for this application"
+    end
+  end


### PR DESCRIPTION
Instead of setting it to a spurious string and risking broken security in case it's ever really used, make an object that will raise an error in that case.
