### PR TITLE
Remove unneeded config line for AMS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ If you want to use the Rails default middleware stack (avoid the reduction that 
 ### Serialization
 
 We suggest using [ActiveModel::Serializers][ams] to serialize your ActiveModel/ActiveRecord objects into the desired response format (e.g. JSON).
-In `ApplicationController` you need to add `include ActionController::Serialization` to make ActiveModelSerializers work.
 
 
 


### PR DESCRIPTION
The current version of AMS, 0.10.0, no longer requires this config for rails-api apps.

New docs: https://github.com/rails-api/active_model_serializers/blob/master/docs/general/getting_started.md#rails-integration
Old docs: https://github.com/rails-api/active_model_serializers/tree/0-9-stable#use-serialization-outside-of-actioncontrollerbase