### PR TITLE
Setup generators in `before_configuration` hook.

### DIFF
--- a/lib/rails-api/application.rb
+++ b/lib/rails-api/application.rb
@@ -16,7 +16,8 @@ module Rails
 
     private
 
-    def setup_generators!
+    ActiveSupport.on_load(:before_configuration) do
+      config.api_only = true
       generators = config.generators
 
       generators.templates.unshift File::expand_path('../templates', __FILE__)
@@ -31,11 +32,6 @@ module Rails
         :stylesheet_engine => nil,
         :template_engine => nil
       })
-    end
-
-    ActiveSupport.on_load(:before_configuration) do
-      config.api_only = true
-      setup_generators!
     end
     
     def check_serve_static_files


### PR DESCRIPTION
Rails 4.2.x introduced a regression where `before_configuration` hooks were no longer run as soon as the Rails Application inherits from `Rails::Application`.
Rails 4.2.8 fixed this regression. However it seems like it broke applications with libraries calling methods from the Application class in the `before_configuration` hook as they do not seem
to be defined.
This commit moves the generator setup in the hook itself.

Rails issue about the regression:
https://github.com/rails/rails/issues/19880

Rails commit introducing the regression:
https://github.com/rails/rails/commit/d25fe31c40928712b5e08fe0afb567c3bc88eddf

Rails PR fixing the regression:
https://github.com/rails/rails/pull/26216

Furthermore this should fix #221.